### PR TITLE
Eligible Menu should handle active/pending request

### DIFF
--- a/cmd/group/eligible/menu/eligibleGroupsMenu.go
+++ b/cmd/group/eligible/menu/eligibleGroupsMenu.go
@@ -59,7 +59,8 @@ func eligibleGroupsMenu(ctx context.Context) error {
 	justification := justificationResult.textInput.Value()
 	statuses := []string{}
 	for _, group := range selectedGroups {
-		status, err := cmdhelper.PIMGroupAssignmentScheduleRequest(ctx, graphClient, 0, group.GroupID, justification)
+		originalStatus, originalErr := cmdhelper.PIMGroupAssignmentScheduleRequest(ctx, graphClient, 0, group.GroupID, justification)
+		status, err := cmdhelper.PIMAssignmentScheduleRequestStatusRewrite(originalStatus, originalErr)
 		if err != nil {
 			return fmt.Errorf("failed to schedule group assignment request for %s: %w", group.Group.DisplayName, err)
 		}

--- a/cmd/role/azure/eligible/menu/eligibleAzureRolesMenu.go
+++ b/cmd/role/azure/eligible/menu/eligibleAzureRolesMenu.go
@@ -58,7 +58,8 @@ func eligibleAzureRolesMenu(ctx context.Context) error {
 	justification := justificationResult.textInput.Value()
 	statuses := []string{}
 	for _, role := range selectedAzureRoles {
-		status, err := cmdhelper.PIMAzureRoleAssignmentScheduleRequest(ctx, azurermClient, role, 0, justification)
+		originalStatus, originalErr := cmdhelper.PIMAzureRoleAssignmentScheduleRequest(ctx, azurermClient, role, 0, justification)
+		status, err := cmdhelper.PIMAssignmentScheduleRequestStatusRewrite(originalStatus, originalErr)
 		if err != nil {
 			return fmt.Errorf("failed to schedule role assignment request for %s (%s): %w", role.Role(), role.Scope(), err)
 		}

--- a/cmd/role/entra/eligible/menu/eligibleEntraRolesMenu.go
+++ b/cmd/role/entra/eligible/menu/eligibleEntraRolesMenu.go
@@ -82,7 +82,8 @@ func eligibleEntraRolesMenu(ctx context.Context, opts *eligibleEntraRolesMenuOpt
 	justification := justificationResult.textInput.Value()
 	statuses := []string{}
 	for _, group := range selectedEntraRoles {
-		status, err := cmdhelper.PIMEntraRoleAssignmentScheduleRequest(ctx, graphClient, 0, group.RoleDefinitionID, justification, opts.entraRoleScopeID)
+		originalStatus, originalErr := cmdhelper.PIMEntraRoleAssignmentScheduleRequest(ctx, graphClient, 0, group.RoleDefinitionID, justification, opts.entraRoleScopeID)
+		status, err := cmdhelper.PIMAssignmentScheduleRequestStatusRewrite(originalStatus, originalErr)
 		if err != nil {
 			return fmt.Errorf("failed to schedule group assignment request for %s: %w", group.RoleDefinition.DisplayName, err)
 		}

--- a/internal/cmdhelper/cmdhelper.go
+++ b/internal/cmdhelper/cmdhelper.go
@@ -3,6 +3,7 @@ package cmdhelper
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
@@ -139,4 +140,20 @@ func PIMAzureRoleAssignmentScheduleRequest(ctx context.Context, azurermClient *a
 	}
 
 	return status, nil
+}
+
+func PIMAssignmentScheduleRequestStatusRewrite(status string, err error) (string, error) {
+	if err == nil {
+		return status, nil
+	}
+
+	if strings.Contains(err.Error(), "There is already an existing pending Role assignment request") {
+		return "PendingApprovalProvisioning", nil
+	}
+
+	if strings.Contains(err.Error(), "The Role assignment already exists") {
+		return "Activated", nil
+	}
+
+	return "", err
 }


### PR DESCRIPTION
This PR introduces logic to handle if any of the requested groups/roles using the `eligible menu` is already pending or activated.

Solves #51 